### PR TITLE
Fix PHP 8 compatibility

### DIFF
--- a/src/Customers.php
+++ b/src/Customers.php
@@ -161,6 +161,6 @@ abstract class Customers extends Extensions\Strict implements Extensions\ICustom
             $this->empty = true;
         }
 
-        return $this->empty ? array() : (count($customers) > 0 ? array_intersect($customers, $output) : $output);
+        return ($this->empty ? array() : (count($customers) > 0 ? array_intersect($customers, $output) : $output));
     }
 }


### PR DESCRIPTION
PHP 8 does not allow inline conditions without parenthesis.